### PR TITLE
Convert to PEP 3110 style exception catching

### DIFF
--- a/celery_haystack/tasks.py
+++ b/celery_haystack/tasks.py
@@ -13,7 +13,7 @@ except ImportError:
         from haystack import site
         from haystack.exceptions import NotRegistered as IndexNotFoundException  # noqa
         legacy = True
-    except ImportError, e:
+    except ImportError as e:
         raise ImproperlyConfigured("Haystack couldn't be imported: %s" % e)
 
 if settings.CELERY_HAYSTACK_TRANSACTION_SAFE and not getattr(settings, 'CELERY_ALWAYS_EAGER', False):
@@ -125,7 +125,7 @@ class CeleryHaystackSignalHandler(Task):
                 try:
                     handler_options = self.get_handler_options(**kwargs)
                     current_index.remove_object(identifier, **handler_options)
-                except Exception, exc:
+                except Exception as exc:
                     logger.exception(exc)
                     self.retry(exc=exc)
                 else:
@@ -146,7 +146,7 @@ class CeleryHaystackSignalHandler(Task):
                 try:
                     handler_options = self.get_handler_options(**kwargs)
                     current_index.update_object(instance, **handler_options)
-                except Exception, exc:
+                except Exception as exc:
                     logger.exception(exc)
                     self.retry(exc=exc)
                 else:

--- a/celery_haystack/utils.py
+++ b/celery_haystack/utils.py
@@ -11,7 +11,7 @@ def get_update_task(task_path=None):
     module, attr = import_path.rsplit('.', 1)
     try:
         mod = import_module(module)
-    except ImportError, e:
+    except ImportError as e:
         raise ImproperlyConfigured('Error importing module %s: "%s"' %
                                    (module, e))
     try:


### PR DESCRIPTION
Moves minimum Python version to 2.6, makes code compatible to Python 3.

Dropping older Django versions may be in order?
