### PR TITLE
Conf queue

### DIFF
--- a/celery_haystack/conf.py
+++ b/celery_haystack/conf.py
@@ -13,6 +13,8 @@ class CeleryHaystack(AppConf):
     MAX_RETRIES = 1
     #: The default Celery task class
     DEFAULT_TASK = 'celery_haystack.tasks.CeleryHaystackSignalHandler'
+    #: The name of the celery queue to use, or None for default
+    QUEUE = None
     #: Whether the task should be handled transaction safe
     TRANSACTION_SAFE = True
 

--- a/celery_haystack/utils.py
+++ b/celery_haystack/utils.py
@@ -28,4 +28,7 @@ def enqueue_task(action, instance):
     model instance.
     """
     identifier = get_identifier(instance)
-    get_update_task().delay(action, identifier)
+    kwargs = {}
+    if settings.CELERY_HAYSTACK_QUEUE:
+        kwargs['queue'] = settings.CELERY_HAYSTACK_QUEUE
+    get_update_task().apply_async([action, identifier], {}, **kwargs)


### PR DESCRIPTION
add CELERY_HAYSTACK_QUEUE conf to allow specification of which celery queue to use.

i run foreground and background queues. the foreground is for time-critical stuff and the background is for stuff that can stack up and take its time to complete. this will leave things going to default celery queue if you do nothing, but allows setting CELERY_HAYSTACK_QUEUE = '<queue-name>' to direct the celery haystack tasks to use an alternate queue (background in my case.)
