### PR TITLE
Handle multiple write-enabled haystack routers

### DIFF
--- a/celery_haystack/signals.py
+++ b/celery_haystack/signals.py
@@ -42,4 +42,3 @@ class CelerySignalProcessor(BaseSignalProcessor):
                 if action == 'update' and not index.should_update(instance):
                     continue
                 enqueue_task(action, instance)
-                return  # Only enqueue instance once


### PR DESCRIPTION
It's possible for a project to have multiple `HAYSTACK_ROUTERS` set up that will handle writes to different search backends: 

http://django-haystack.readthedocs.org/en/latest/settings.html#haystack-routers

Currently in celery-haystack, the signal handler returns after finding the first writable backend, which this commit fixes.

You can also see here in haystack's default signal handler that the behaviour is different - it doesn't return after finding the first writable backend:

https://github.com/toastdriven/django-haystack/blob/f80cb9f92db1bf080ea5c1bc7e7bff34b1b8ce72/haystack/signals.py#L38-L51

I'm not sure if the early return in celery-haystack is masking another bug where the same task was being enqueued multiple times, or if it was just a minor optimisation - hopefully the latter, but if the former, then this one-line fix is probably insufficient.

Thanks!
