### PR TITLE
Fix missing importlib.

### DIFF
--- a/celery_haystack/tasks.py
+++ b/celery_haystack/tasks.py
@@ -1,6 +1,11 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
-from django.db.models.loading import get_model
+
+try:
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models.loading import get_model
 
 from .conf import settings
 

--- a/celery_haystack/utils.py
+++ b/celery_haystack/utils.py
@@ -1,5 +1,9 @@
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 from django.db import connection
 
 from haystack.utils import get_identifier


### PR DESCRIPTION
Hi,

`import_module ` was dropped from Django 1.9. This is an easy hack to solve problems over Python 2.6 to 3.x.