### PR TITLE
Separate Task/Queue for SearchIndex #59

### DIFF
--- a/celery_haystack/__init__.py
+++ b/celery_haystack/__init__.py
@@ -1,9 +1,5 @@
 __version__ = '0.10'
 
 
-# this is not a django AppConfig object and therefore needs to be imported here so other tasks can subclass CeleryHaystackSignalHandler
-from .conf import CeleryHaystack
-
-
 def version_hook(config):
     config['metadata']['version'] = __version__

--- a/celery_haystack/__init__.py
+++ b/celery_haystack/__init__.py
@@ -1,5 +1,9 @@
 __version__ = '0.10'
 
 
+# this is not a django AppConfig object and therefore needs to be imported here so other tasks can subclass CeleryHaystackSignalHandler
+from .conf import CeleryHaystack
+
+
 def version_hook(config):
     config['metadata']['version'] = __version__

--- a/celery_haystack/apps.py
+++ b/celery_haystack/apps.py
@@ -1,6 +1,6 @@
 from .conf import CeleryHaystack # this populates our settings
-from django.apps import apps as django_apps
+from django.apps import AppConfig
 
 
-class CeleryHaystackAppConfig(django_apps.AppConfig):
+class CeleryHaystackAppConfig(AppConfig):
     name = "celery_haystack"

--- a/celery_haystack/apps.py
+++ b/celery_haystack/apps.py
@@ -1,0 +1,6 @@
+from .conf import  # this populates our settings
+from django.apps import apps as django_apps
+
+
+class CeleryHaystackAppConfig(django_apps.AppConfig):
+    name = "celery_haystack"

--- a/celery_haystack/apps.py
+++ b/celery_haystack/apps.py
@@ -1,4 +1,4 @@
-from .conf import  # this populates our settings
+from .conf import CeleryHaystack # this populates our settings
 from django.apps import apps as django_apps
 
 

--- a/celery_haystack/conf.py
+++ b/celery_haystack/conf.py
@@ -20,6 +20,8 @@ class CeleryHaystack(AppConf):
     QUEUE = None
     #: Whether the task should be handled transaction safe
     TRANSACTION_SAFE = True
+    #: Whether the task shoild ignore results
+    IGNORE_RESULTS = False
 
     #: The batch size used by the CeleryHaystackUpdateIndex task
     COMMAND_BATCH_SIZE = None

--- a/celery_haystack/indexes.py
+++ b/celery_haystack/indexes.py
@@ -2,4 +2,4 @@ from haystack import indexes
 
 
 class CelerySearchIndex(indexes.SearchIndex):
-    pass
+    task_path = None

--- a/celery_haystack/signals.py
+++ b/celery_haystack/signals.py
@@ -3,8 +3,8 @@ from django.db.models import signals
 from haystack.signals import BaseSignalProcessor
 from haystack.exceptions import NotHandled
 
-from celery_haystack.utils import enqueue_task
-from celery_haystack.indexes import CelerySearchIndex
+from .utils import enqueue_task
+from .indexes import CelerySearchIndex
 
 
 class CelerySignalProcessor(BaseSignalProcessor):

--- a/celery_haystack/signals.py
+++ b/celery_haystack/signals.py
@@ -41,4 +41,4 @@ class CelerySignalProcessor(BaseSignalProcessor):
             if isinstance(index, CelerySearchIndex):
                 if action == 'update' and not index.should_update(instance):
                     continue
-                enqueue_task(action, instance)
+                enqueue_task(action, instance, task_path=index.task_path)

--- a/celery_haystack/signals.py
+++ b/celery_haystack/signals.py
@@ -3,8 +3,8 @@ from django.db.models import signals
 from haystack.signals import BaseSignalProcessor
 from haystack.exceptions import NotHandled
 
-from .utils import enqueue_task
-from .indexes import CelerySearchIndex
+from celery_haystack.utils import enqueue_task
+from celery_haystack.indexes import CelerySearchIndex
 
 
 class CelerySignalProcessor(BaseSignalProcessor):

--- a/celery_haystack/tasks.py
+++ b/celery_haystack/tasks.py
@@ -19,6 +19,7 @@ class CeleryHaystackSignalHandler(Task):
     using = settings.CELERY_HAYSTACK_DEFAULT_ALIAS
     max_retries = settings.CELERY_HAYSTACK_MAX_RETRIES
     default_retry_delay = settings.CELERY_HAYSTACK_RETRY_DELAY
+    ignore_result = settings.CELERY_HAYSTACK_IGNORE_RESULTS
 
     def split_identifier(self, identifier, **kwargs):
         """

--- a/celery_haystack/utils.py
+++ b/celery_haystack/utils.py
@@ -7,7 +7,7 @@ from django.db import connection, transaction
 
 from haystack.utils import get_identifier
 
-from celery_haystack.conf import settings
+from .conf import settings
 
 
 def get_update_task(task_path=None):

--- a/celery_haystack/utils.py
+++ b/celery_haystack/utils.py
@@ -38,7 +38,8 @@ def enqueue_task(action, instance, **kwargs):
     if settings.CELERY_HAYSTACK_COUNTDOWN:
         options['countdown'] = settings.CELERY_HAYSTACK_COUNTDOWN
 
-    task = get_update_task()
+    task_path = kwargs.get('task_path', None)
+    task = get_update_task(task_path=task_path)
 
     def task_func():
         return task.apply_async((action, identifier), kwargs, **options)

--- a/celery_haystack/utils.py
+++ b/celery_haystack/utils.py
@@ -7,7 +7,7 @@ from django.db import connection, transaction
 
 from haystack.utils import get_identifier
 
-from .conf import settings
+from celery_haystack.conf import settings
 
 
 def get_update_task(task_path=None):


### PR DESCRIPTION
As discussed here: https://github.com/django-haystack/celery-haystack/issues/59

Developed support for a specific Search Index to use a specific task path in order to leverage celery's queue routing to better manage resources (e.g. the number of workers) to complete certain real time indexes fast enough.

I also added the django app conf, since thats the new way to do things with the app loader. I also added Task class support of IGNORE_RESULTS via a setting.
