### PR TITLE
Check if an object is still in index_queryset

### DIFF
--- a/celery_haystack/indexes.py
+++ b/celery_haystack/indexes.py
@@ -2,4 +2,12 @@ from haystack import indexes
 
 
 class CelerySearchIndex(indexes.SearchIndex):
-    pass
+    
+    def update_object(self, instance, using=None, **kwargs):
+        """Remove an object if it is no longer in the index_queryset"""
+
+        ids = self.index_queryset(**kwargs).values_list('id', flat=True)
+        if instance.id not in ids:
+            self.remove_object(instance)
+        else:
+            super(ProjectIndex, self).update_object(instance, using, **kwargs)


### PR DESCRIPTION
There is an issue where if an object is updated in a way that removes it from the index_queryset it does not get removed upon update.  This can be fixed by overriding update_object or instead should_update to check if an object is no longer in the queryset and removing instead of updating.