### PR TITLE
Pass signal `**kwargs` to `index.should_update`

### DIFF
--- a/celery_haystack/signals.py
+++ b/celery_haystack/signals.py
@@ -39,6 +39,6 @@ class CelerySignalProcessor(BaseSignalProcessor):
                 continue  # Check next backend
 
             if isinstance(index, CelerySearchIndex):
-                if action == 'update' and not index.should_update(instance):
+                if action == 'update' and not index.should_update(instance, **kwargs):
                     continue
                 enqueue_task(action, instance)


### PR DESCRIPTION
In the django-haystack documentation, [it's said](https://django-haystack.readthedocs.io/en/master/searchindex_api.html?highlight=should_update#SearchIndex.should_update) that signal keyword arguments will be passed to `should_update`, and sure enough they are [here](https://github.com/django-haystack/django-haystack/blob/802b0f6f4b3b99314453261876a32bac2bbec94f/haystack/indexes.py#L318-L319).

I'm implementing custom signals to be used with celery-haystack and would like to do some fancy checking in `should_update` to see if my django model objects should be reindexed.  I've made this same change in our fork of celery-haystack, and thought I'd submit it upstream.

(Looks like this is very tangentially related to issue #61.)