### PR TITLE
Add setting CELERY_HAYSTACK_IGNORE_RESULT

### DIFF
--- a/celery_haystack/conf.py
+++ b/celery_haystack/conf.py
@@ -20,6 +20,8 @@ class CeleryHaystack(AppConf):
     QUEUE = None
     #: Whether the task should be handled transaction safe
     TRANSACTION_SAFE = True
+    #: Whether the task results should be ignored
+    IGNORE_RESULT = False
 
     #: The batch size used by the CeleryHaystackUpdateIndex task
     COMMAND_BATCH_SIZE = None

--- a/celery_haystack/tasks.py
+++ b/celery_haystack/tasks.py
@@ -17,6 +17,8 @@ class CeleryHaystackSignalHandler(Task):
     using = settings.CELERY_HAYSTACK_DEFAULT_ALIAS
     max_retries = settings.CELERY_HAYSTACK_MAX_RETRIES
     default_retry_delay = settings.CELERY_HAYSTACK_RETRY_DELAY
+    ignore_result = settings.CELERY_HAYSTACK_IGNORE_RESULT
+    store_errors_even_if_ignored = True
 
     def split_identifier(self, identifier, **kwargs):
         """


### PR DESCRIPTION
If True, results of the signal handler task will not be written to any
result store to not produce large amounts of irrelevant results.

Errors will still be stored.