### PR TITLE
ruff --target-version=py39

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: pip install --user codespell[toml] ruff
+    - run: pipx install codespell[toml] ruff
     - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
-    - run: ruff check --output-format=github --target-version=py38 .
+    - run: ruff check --output-format=github --target-version=py39


### PR DESCRIPTION
Python 3.8 is no longer supported.  https://devguide.python.org/versions